### PR TITLE
avoid overloading the term ecosystem

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,3 @@
+template: ecosystem.html
+
+# Ansible ecosystem

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,8 @@ You can explore Ansible projects and find links to the related documentation.
 
 ## Extending Ansible automation
 
-Ansible is a programming language and runtime plus an entire ecosystem of projects that extends automation capabilities to a virtually unlimited set of use cases.
-
-For example, the Ansible ecosystem gives you tools you need to:
+Ansible is a project ecosystem that extends automation capabilities to a wide range of use cases.
+For example, the Ansible ecosystem provides tooling to:
 
 * Create consistent, reliable playbooks for trusted automation
 * Add automation to your `ci` workflows

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,27 @@
-template: ecosystem.html
+Welcome to `Ansible ecosystem documentation`.
 
-# Ansible ecosystem
+Here you can find `How To` guides and `tutorials` for cross-project use cases within the Ansible ecosystem in this docsite.
+
+If you're looking for documentation related to a specific Ansible project, visit the [ecosystem page](ecosystem.md).
+You can explore Ansible projects and find links to the related documentation.
+
+## Extending Ansible automation
+
+Ansible is a programming language and runtime plus an entire ecosystem of projects that extending automation capabilities to a virtually unlimited set of use cases.
+
+For example, the Ansible ecosystem gives you tools you need to:
+
+* Create consistent, reliable playbooks for trusted automation
+* Add automation to your `ci` workflows
+* Build and use containerized control nodes
+* Use community collections for automation
+* Build a network mesh for executing automation jobs
+
+The goal of the Ansible ecosystem documentation is to provide you with procedures for these various use cases.
+
+## Share your automation knowledge
+
+We love to learn too!
+The Ansible community encourages everyone to share what they know about automation, whether it's writing playbooks or building automation solutions.
+If you see something missing, have an idea for new content, or want to leave some feedback, get involved.
+Go to the repository to fork and submit a pull request or create a new issue that captures the details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ You can explore Ansible projects and find links to the related documentation.
 
 ## Extending Ansible automation
 
-Ansible is a programming language and runtime plus an entire ecosystem of projects that extending automation capabilities to a virtually unlimited set of use cases.
+Ansible is a programming language and runtime plus an entire ecosystem of projects that extends automation capabilities to a virtually unlimited set of use cases.
 
 For example, the Ansible ecosystem gives you tools you need to:
 

--- a/layout/ecosystem.html
+++ b/layout/ecosystem.html
@@ -221,7 +221,7 @@
         </div>
         <div class="width-9-12 width-12-12-m">
             <h2>Ansible ecosystem</h2>
-            <p>Projects in the Ansible ecosystem let you expand automation to a virtually unlimited set of use cases.</p>
+            <p>Discover automation tooling in the Ansible ecosystem and find links to project documentation.</p>
         </div>
         {% for project in projects %}
             <div class="width-6-12 width-12-12-m">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ theme:
 
 nav:
   - index.md
+  - ecosystem.md
 
 exclude_docs:
   README.md


### PR DESCRIPTION
* rename the site title
* make purpose clear in the index
* move ecosystem to a secondary page