### PR TITLE
port over the ee getting started guide

### DIFF
--- a/docs/getting_started_ee/build_execution_environment.md
+++ b/docs/getting_started_ee/build_execution_environment.md
@@ -1,0 +1,67 @@
+# Building your first Execution Environment
+
+We are going to build an EE that represents an Ansible control node containing standard packages such as `ansible-core` and Python in addition to an Ansible collection (`community.postgresql`) and its dependency (the `psycopg2-binary` Python connector).
+
+To build your first EE:
+
+1. Create a project folder on your filesystem.
+
+    ``` bash
+    mkdir my_first_ee && cd my_first_ee
+    ```
+
+2. Create a `execution-environment.yml` file that specifies dependencies to include in the image.
+
+    ``` yaml
+    cat > execution-environment.yml<<EOF
+    version: 3
+
+    images:
+      base_image:
+        name: quay.io/fedora/fedora:latest
+
+    dependencies:
+      ansible_core:
+        package_pip: ansible-core
+      ansible_runner:
+        package_pip: ansible-runner
+      system:
+      - openssh-clients
+      - sshpass
+      galaxy:
+        collections:
+        - name: community.postgresql
+    EOF
+    ```
+
+    > The `psycopg2-binary` Python package is included in the `requirements.txt` file for the collection.
+    > For collections that do not include `requirements.txt` files, you need to specify Python dependencies explicitly.
+    > See the [Ansible Builder documentation](https://ansible-builder.readthedocs.io/en/stable/definition/) for details.
+
+3. Build a EE container image called `postgresql_ee`.
+
+    If you use docker, add the `--container-runtime docker` argument.
+
+    ``` bash
+    ansible-builder build --tag postgresql_ee
+    ```
+
+4. List container images to verify that you built it successfully.
+
+    ``` bash
+    podman image list
+
+    localhost/postgresql_ee          latest      2e866777269b  6 minutes ago  1.11 GB
+    ```
+
+You can verify the image you created by inspecting the `Containerfile` or `Dockerfile` in the `context` directory to view its configuration.
+
+``` bash
+less context/Containerfile
+```
+
+You can also use Ansible Navigator to view detailed information about the image.
+
+Run the `ansible-navigator` command, type `:images` in the TUI, and then choose `postgresql_ee`.
+
+Proceed to [Running your EE](run_execution_environment.md) and test the EE you just built.

--- a/docs/getting_started_ee/index.md
+++ b/docs/getting_started_ee/index.md
@@ -1,0 +1,23 @@
+# Getting started with Execution Environments
+
+You can run Ansible automation in containers, like any other modern software application.
+Ansible uses container images known as Execution Environments (EE) that act as control nodes.
+
+An Execution Environment image contains the following packages as standard:
+
+- `ansible-core`
+- `ansible-runner`
+- Python
+- Ansible content dependencies
+
+In addition to the standard packages, an EE can also contain:
+
+-   one or more Ansible collections and their dependencies
+-   other custom components
+
+This getting started guide shows you how to build and test a simple Execution Environment.
+The resulting container image represents an Ansible control node that contains:
+
+- standard EE packages
+- `community.postgresql` collection
+- `psycopg2-binary` Python package

--- a/docs/getting_started_ee/introduction.md
+++ b/docs/getting_started_ee/introduction.md
@@ -1,0 +1,62 @@
+# Introduction to Execution Environments
+
+Ansible Execution Environments aim to resolve complexity issues and provide all the benefits you can get from containerization.
+
+## Reducing complexity
+
+There are three main areas where EEs can reduce complexity:
+
+- software dependencies
+- portability
+- content separation
+
+### Dependencies
+
+Software applications typically have dependencies, and Ansible is no exception.
+These dependencies can include software libraries, configuration files or other services, to name a few.
+
+Traditionally, administrators install application dependencies on top of an operating system using packaging management tools such as RPM or Python-pip.
+
+The major drawback of such an approach is that an application might require versions of dependencies different from those provided by default.
+
+For Ansible, a typical installation consists of `ansible-core` and a set of Ansible collections.
+Many of them have dependencies for the plugins, modules, roles and playbooks they provide.
+
+The Ansible collections can depend on the following pieces of software and their versions:
+
+-   `ansible-core`
+-   Python
+-   Python packages
+-   System packages
+-   Other Ansible collections
+
+The dependencies have to be installed and sometimes can conflict with each other.
+
+One way to **partially** resolve the dependency issue is to use Python virtual environments on Ansible control nodes.
+However, applied to Ansible, virtual environments have drawbacks and natural limitations.
+
+### Portability
+
+An Ansible user writes content for Ansible locally and wants to leverage the container technology to make their automation runtimes portable, shareable and easily deployable to testing and production environments.
+
+### Content separation
+
+In situations when there is an Ansible control node or a tool such as Ansible AWX/Controller used by several users, they might want separate
+their content to avoid configuration and dependency conflicts.
+
+## Ansible tooling for EEs
+
+Projects in the Ansible ecosystem also provide several tools that you can use with EEs, such as:
+
+-   [Ansible Builder](https://ansible-builder.readthedocs.io/en/stable/)
+-   [Ansible Navigator](https://ansible-navigator.readthedocs.io/)
+-   [Ansible
+    AWX](https://ansible.readthedocs.io/projects/awx/en/latest/userguide/execution_environments.html#use-an-execution-environment-in-jobs)
+-   [Ansible Runner](https://ansible-runner.readthedocs.io/en/stable/)
+-   VS Code
+    [Ansible](https://marketplace.visualstudio.com/items?itemName=redhat.ansible)
+    and [Dev
+    Containers](https://code.visualstudio.com/docs/devcontainers/containers)
+    extensions
+
+Ready to get started with EEs? Proceed to [Setting up your environment](setup_environment.md).

--- a/docs/getting_started_ee/run_community_ee_image.md
+++ b/docs/getting_started_ee/run_community_ee_image.md
@@ -1,0 +1,43 @@
+# Running Ansible with the community EE image
+
+You can run ansible without the need to build a custom EE using
+community images.
+Use the `community-ee-minimal` image that includes only `ansible-core` or the `community-ee-base` image that also includes several base collections.
+
+Run the following command to see the collections included in the `community-ee-base` image:
+
+``` bash
+ansible-navigator collections --execution-environment-image ghcr.io/ansible-community/community-ee-base:latest
+```
+
+Run the following Ansible ad-hoc command against localhost inside the `community-ee-minimal` container:
+
+``` bash
+ansible-navigator exec "ansible localhost -m setup" --execution-environment-image ghcr.io/ansible-community/community-ee-minimal:latest --mode stdout
+```
+
+Now, create a simple test playbook and run it against localhost inside the container:
+
+``` yaml
+cat > test_localhost.yml<<EOF
+- name: Gather and print local facts
+  hosts: localhost
+  become: yes
+  gather_facts: yes
+  tasks:
+
+  - name: Print facts
+    ansible.builtin.debug:
+      var: ansible_facts
+EOF
+```
+
+``` bash
+ansible-navigator run test_localhost.yml --execution-environment-image ghcr.io/ansible-community/community-ee-minimal:latest --mode stdout
+```
+
+## See also
+
+- [Building your first EE](build_execution_environment.md)
+- [Running your EE](run_execution_environment.md)
+- [Ansible Navigator documentation](https://ansible-navigator.readthedocs.io/)

--- a/docs/getting_started_ee/run_execution_environment.md
+++ b/docs/getting_started_ee/run_execution_environment.md
@@ -1,0 +1,90 @@
+# Running your EE
+
+You can run your EE on the command line against `localhost` or a remote target using `ansible-navigator`.
+
+> There are other tools besides `ansible-navigator` you can run EEs with.
+
+## Run against localhost
+
+1.  Create a `test_localhost.yml` playbook.
+
+    ``` yaml
+    cat > test_localhost.yml<<EOF
+    - name: Gather and print local facts
+      hosts: localhost
+      become: yes
+      gather_facts: yes
+      tasks:
+
+      - name: Print facts
+        ansible.builtin.debug:
+          var: ansible_facts
+    EOF
+    ```
+
+2.  Run the playbook inside the `postgresql_ee` EE.
+
+    ``` bash
+    ansible-navigator run test_localhost.yml --execution-environment-image postgresql_ee --mode stdout --pull-policy missing --container-options='--user=0'
+    ```
+
+You may notice the facts being gathered are about the container and not the developer machine.
+This is because the ansible playbook was run inside the container.
+
+## Run against a remote target
+
+Before you start, ensure you have the following:
+
+  * At least one IP address or resolvable hostname for a remote target.
+  * Valid credentials for the remote host.
+  * A user with `sudo` permissions on the remote host.
+
+Execute a playbook inside the `postgresql_ee` EE against a remote host machine as in the following example:
+
+1. Create a directory for inventory files.
+
+    ``` yaml
+    mkdir inventory
+    ```
+
+2. Create the `hosts.yml` inventory file in the `inventory` directory.
+
+    ``` yaml
+    cat > inventory/hosts.yml<<EOF
+    all:
+      hosts:
+        192.168.0.2  # Replace with the IP of your target host
+    EOF
+    ```
+
+3. Create a `test_remote.yml` playbook.
+
+    ``` yaml
+    cat > test_remote.yml<<EOF
+    - name: Gather and print facts
+      hosts: all
+      become: yes
+      gather_facts: yes
+      tasks:
+
+      - name: Print facts
+        ansible.builtin.debug:
+          var: ansible_facts
+    EOF
+    ```
+
+4. Run the playbook inside the `postgresql_ee` EE.
+
+    Replace `student` with the appropriate username.
+    Some arguments in the command can be optional depending on your target host authentication method.
+
+    ``` bash
+    ansible-navigator run test_remote.yml -i inventory --execution-environment-image postgresql_ee:latest --mode stdout --pull-policy missing --enable-prompts -u student -k -K
+    ```
+
+## See also
+
+- [Execution Environment Definition](https://ansible-builder.readthedocs.io/en/stable/definition/) provides information about the about Execution Environment definition file and available options.
+- [Ansible Builder CLI usage](https://ansible-builder.readthedocs.io/en/stable/usage/)
+- [Ansible Navigator documentation](https://ansible-navigator.readthedocs.io/)
+- [Running a local container registry for EEs](https://forum.ansible.com/t/running-local-container-registry-for-execution-environments/206)

--- a/docs/getting_started_ee/setup_environment.md
+++ b/docs/getting_started_ee/setup_environment.md
@@ -1,0 +1,40 @@
+# Setting up your environment
+
+Complete the following steps to set up a local environment for your first Execution Environment:
+
+1. Ensure the following packages are installed on your system:
+
+    * `podman` or `docker`
+    * `python3`
+
+    If you use the DNF package manager, install these prerequisites as follows:
+
+    ``` bash
+    sudo dnf install -y podman python3
+    ```
+
+2. Install `ansible-navigator`:
+
+    ``` bash
+    pip3 install ansible-navigator
+    ```
+
+    Installing `ansible-navigator` lets you run EEs on the command line.
+    It includes the `ansible-builder` package to build EEs.
+
+    If you want to build EEs without testing, install only `ansible-builder`:
+
+    ``` bash
+    pip3 install ansible-builder
+    ```
+
+3. Verify your environment with the following commands:
+
+    ``` bash
+    ansible-navigator --version
+    ansible-builder --version
+    ```
+
+Ready to build an EE in a few easy steps? Proceed to [Building your first EE](build_execution_environment.md).
+
+Want to try an EE without having to build one? Proceed to [Running the community EE](run_community_ee_image.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
   - ecosystem.md
   - Getting started with execution environments:
     - index: getting_started_ee/index.md
-    - Introduction: getting_started_ee/introduction.md
+    - getting_started_ee/introduction.md
     - getting_started_ee/setup_environment.md
     - getting_started_ee/build_execution_environment.md
     - getting_started_ee/run_execution_environment.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,6 @@ theme:
     - content.code.copy
     - content.action.edit
     - navigation.expand
-    - navigation.sections
     - navigation.instant
     - navigation.indexes
     - navigation.tracking
@@ -41,6 +40,13 @@ theme:
 nav:
   - index.md
   - ecosystem.md
+  - Getting started with execution environments:
+    - index: getting_started_ee/index.md
+    - Introduction: getting_started_ee/introduction.md
+    - getting_started_ee/setup_environment.md
+    - getting_started_ee/build_execution_environment.md
+    - getting_started_ee/run_execution_environment.md
+    - getting_started_ee/run_community_ee_image.md
 
 exclude_docs:
   README.md


### PR DESCRIPTION
This PR moves the "Getting started with execution environments" content from the `ansible-documentation` repository. As part of this PR, the format is converted from RST to markdown.

The justification for this move is that the content in the `ansible-documentation` repository focuses on the Ansible package and Ansible core. EEs are outside that scope and involve various projects within the ecosystem.

After this PR is merged and the content is available on readthedoc we'll need to setup redirects from `https://docs.ansible.com/ansible/devel/getting_started_ee/index.html`. We should investigate whether we can do this from the readthedocs project settings.