### PR TITLE
Add mkdocs redirects

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,10 @@ plugins:
           import:
             - url: https://docs.ansible.com/ansible/latest/objects.inv
               domains: [py, std]
+  - redirects:
+      redirect_maps:
+        'ecosystem.md': 'https://docs.ansible.com/ecosystem.html'
+
 
 markdown_extensions:
   - admonition

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,2 +1,3 @@
 mkdocs
 mkdocs-ansible
+mkdocs-redirects

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -77,6 +77,7 @@ mkdocs==1.5.3
     #   mkdocs-material
     #   mkdocs-minify-plugin
     #   mkdocs-monorepo-plugin
+    #   mkdocs-redirects
     #   mkdocstrings
 mkdocs-ansible==0.2.0
     # via -r tests/requirements.in
@@ -96,6 +97,8 @@ mkdocs-minify-plugin==0.7.1
     # via mkdocs-ansible
 mkdocs-monorepo-plugin==1.0.5
     # via mkdocs-ansible
+mkdocs-redirects==1.2.1
+    # via -r tests/requirements.in
 mkdocstrings==0.24.0
     # via
     #   mkdocs-ansible


### PR DESCRIPTION
This PR adds [`mkdocs-redirects`](https://github.com/mkdocs/mkdocs-redirects) and sets up a redirect for the ecosystem page that was removed with https://github.com/ansible/ecosystem-documentation/commit/f691e36bc45e99b2e3893d2b85ab0bd7a7e8e118

Reading through the mkdocs-redirects documentation it seems like it might be a good idea to fix https://github.com/ansible/ecosystem-documentation/issues/21 before we merge this. I'll send a separate PR.
