### PR TITLE
allow pip compile without upgrading

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def pip_compile(session: nox.Session, req: str):
     # Use --upgrade by default unless a user passes -P.
     args = list(session.posargs)
     if not any(
-        arg.startswith("-P") or arg.startswith("--upgrade-package") for arg in args
+        arg.startswith(("-P", "--upgrade-package", "--no-upgrade")) for arg in args
     ):
         args.append("--upgrade")
 


### PR DESCRIPTION
Separating this commit from https://github.com/ansible/ecosystem-documentation/pull/28

This PR adds the `no-upgrade` flag to the nox session for pip compiling requirements. This change allows to add or update specific requirements without upgrading all packages. 